### PR TITLE
Fix code scanning alert no. 4: Query built from user-controlled sources

### DIFF
--- a/app/src/main/java/lab/insecuredroid/challenges/utils/DBHelper.java
+++ b/app/src/main/java/lab/insecuredroid/challenges/utils/DBHelper.java
@@ -30,8 +30,8 @@ public class DBHelper extends SQLiteOpenHelper {
         boolean exists = false;
         SQLiteDatabase db = this.getReadableDatabase();
         try {
-            String sql = "SELECT * FROM users WHERE username = '" + username + "' AND password = '" + hashPassword(password) + "'";
-            Cursor cursor = db.rawQuery(sql, null);
+            String sql = "SELECT * FROM users WHERE username = ? AND password = ?";
+            Cursor cursor = db.rawQuery(sql, new String[]{username, hashPassword(password)});
             exists = (cursor.getCount() > 0);
             cursor.close();
             db.close();


### PR DESCRIPTION
Fixes [https://github.com/krsti4n-war/InsecureDroid/security/code-scanning/4](https://github.com/krsti4n-war/InsecureDroid/security/code-scanning/4)

To fix the problem, we need to replace the string concatenation used to build the SQL query with a prepared statement. Prepared statements allow us to safely include user input in SQL queries by using placeholders and binding the actual values separately. This approach prevents SQL injection attacks by ensuring that user input is treated as data rather than executable code.

**Steps to fix the problem:**
1. Modify the `vulnerable_login` method in `DBHelper.java` to use a prepared statement instead of string concatenation.
2. Use placeholders (`?`) in the SQL query and bind the `username` and `hashedPassword` values to these placeholders.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
